### PR TITLE
cmd: handling tilde '~' escaping correctly

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -503,7 +503,7 @@ func normalizeFilePath(fp string) string {
 		"\\\\", "\\", // Escaped backslash
 		"\\*", "*", // Escaped asterisk
 		"\\?", "?", // Escaped question mark
-
+		"\\~", "~", // Escaped tilde 
 	).Replace(fp)
 }
 


### PR DESCRIPTION
fix for : https://github.com/ollama/ollama/issues/10333